### PR TITLE
fix: json rpc id field type

### DIFF
--- a/rpc/websockets.go
+++ b/rpc/websockets.go
@@ -55,7 +55,7 @@ type WebsocketsServer interface {
 type SubscriptionResponseJSON struct {
 	Jsonrpc string      `json:"jsonrpc"`
 	Result  interface{} `json:"result"`
-	ID      float64     `json:"id"`
+	ID      interface{} `json:"id"`
 }
 
 type SubscriptionNotification struct {
@@ -72,7 +72,7 @@ type SubscriptionResult struct {
 type ErrorResponseJSON struct {
 	Jsonrpc string            `json:"jsonrpc"`
 	Error   *ErrorMessageJSON `json:"error"`
-	ID      *big.Int          `json:"id"`
+	ID      interface{}       `json:"id"`
 }
 
 type ErrorMessageJSON struct {
@@ -225,7 +225,7 @@ func (s *websocketsServer) readLoop(wsConn *wsConn) {
 			continue
 		}
 
-		connID, ok := msg["id"].(float64)
+		connID, ok := msg["id"]
 		if !ok {
 			s.sendErrResponse(
 				wsConn,


### PR DESCRIPTION
Fixes bad handling of the id field in a json rpc request. 

As per [the spec](https://www.jsonrpc.org/specification#request_object):

> id
>   An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [[1]](https://www.jsonrpc.org/specification#id1) and Numbers SHOULD NOT contain fractional parts [[2]](https://www.jsonrpc.org/specification#id2)